### PR TITLE
fix: dmgビルドとPackaging設定のパス修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+*.manifest
+# Note: .spec files are usually tracked as they are configuration files
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# PyQt5/GUI related
+*.ui
+
+# Build artifacts
+*.dmg
+*.app
+*.pkg
+
+# Virtual environment
+venv/
+env/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+*.log

--- a/dmg_settings.py
+++ b/dmg_settings.py
@@ -6,7 +6,7 @@ import os.path
 
 # Use like this: dmgbuild -s settings.py "Test Volume" test.dmg
 
-application = defines.get('app', '/Users/shoheishimizu/Python/webp-converter/dist/webp-converter.app')
+application = defines.get('app', './dist/webp-converter.app')
 appname = os.path.basename(application)
 
 def icon_from_app(app_path):

--- a/webp-converter.spec
+++ b/webp-converter.spec
@@ -2,7 +2,7 @@
 
 
 a = Analysis(
-    ['/Users/shoheishimizu/Python/webp-converter/webp-converter.py'],
+    ['./webp-converter.py'],
     pathex=[],
     binaries=[],
     datas=[],
@@ -32,7 +32,7 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    icon=['/Users/shoheishimizu/Python/webp-converter/webp-app.ico'],
+    icon=['./webp-app.ico'],
 )
 coll = COLLECT(
     exe,
@@ -46,6 +46,6 @@ coll = COLLECT(
 app = BUNDLE(
     coll,
     name='webp-converter.app',
-    icon='/Users/shoheishimizu/Python/webp-converter/webp-app.ico',
+    icon='./webp-app.ico',
     bundle_identifier=None,
 )


### PR DESCRIPTION
- dmg_settings.py: 絶対パスから相対パスに変更
- webp-converter.spec: プロジェクト名とアイコンパスを修正
- .gitignore: ビルド成果物とmacOS固有ファイルを除外

これにより、異なる環境でのdmg作成が可能になります。